### PR TITLE
feat(jobs): adds scheduling of maintenance tasks for news publishing …

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
 				"dotenv": "^16.5.0",
 				"express": "^5.1.0",
 				"lodash": "^4.17.21",
+				"node-cron": "^4.2.0",
 				"prisma": "^6.8.2",
 				"zod": "^3.25.42"
 			},
@@ -23,6 +24,7 @@
 				"@types/jest": "^29.5.12",
 				"@types/lodash": "^4.17.19",
 				"@types/node": "^22.15.29",
+				"@types/node-cron": "^3.0.11",
 				"jest": "^29.7.0",
 				"supertest": "^7.1.1",
 				"ts-jest": "^29.1.2",
@@ -1366,6 +1368,13 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
+		},
+		"node_modules/@types/node-cron": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+			"integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/phoenix": {
 			"version": "1.6.6",
@@ -4188,6 +4197,15 @@
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/node-cron": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.0.tgz",
+			"integrity": "sha512-nOdP7uH7u55w7ybQq9fusXtsResok+ErzvOBydJUPBBaQ9W+EfBaBWFPgJ8sOB7FWQednDvVBJtgP5xA0bME7Q==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/node-int64": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
 		"dotenv": "^16.5.0",
 		"express": "^5.1.0",
 		"lodash": "^4.17.21",
+		"node-cron": "^4.2.0",
 		"prisma": "^6.8.2",
 		"zod": "^3.25.42"
 	},
@@ -26,6 +27,7 @@
 		"@types/jest": "^29.5.12",
 		"@types/lodash": "^4.17.19",
 		"@types/node": "^22.15.29",
+		"@types/node-cron": "^3.0.11",
 		"jest": "^29.7.0",
 		"supertest": "^7.1.1",
 		"ts-jest": "^29.1.2",

--- a/backend/src/modules/publisher/publisher.schemas.ts
+++ b/backend/src/modules/publisher/publisher.schemas.ts
@@ -37,6 +37,9 @@ export const createNewsSchema = z.object({
       .array(z.string().uuid({ message: 'ID de categoria inválido.' }))
       .min(1, 'Pelo menos uma categoria é necessária.'),
     media: z.array(mediaSchema).optional().default([]),
+    publishedAt: z.coerce.date().optional(),
+    mainPageDisplayDate: z.coerce.date().optional(),
+    newsListPageDate: z.coerce.date().optional(),
   }),
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,7 +1,9 @@
 import app from './app';
+import { scheduleMaintenanceJob } from './shared/jobs/maintenance.job';
 
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);
+  scheduleMaintenanceJob();
 });

--- a/backend/src/shared/jobs/maintenance.job.ts
+++ b/backend/src/shared/jobs/maintenance.job.ts
@@ -1,0 +1,101 @@
+import cron from 'node-cron';
+import prisma from '../lib/prisma';
+
+/**
+ * Publishes all approved news items that are scheduled to be published and have not yet been published.
+ *
+ * This function queries the database for news items that:
+ * - Have a status of 'APPROVED'
+ * - Are not yet published (`published: false`)
+ * - Have a `publishedAt` date less than or equal to the current date
+ *
+ * If any such news items are found, it updates their `published` field to `true`.
+ */
+const publishScheduledNews = async () => {
+  const newsToPublish = await prisma.news.findMany({
+    where: {
+      status: 'APPROVED',
+      published: false,
+      publishedAt: {
+        lte: new Date(),
+      },
+    },
+  });
+
+  if (newsToPublish.length > 0) {
+    console.log(
+      `[JOB] Encontrados ${newsToPublish.length} notícias para publicar`
+    );
+
+    await prisma.news.updateMany({
+      where: {
+        id: {
+          in: newsToPublish.map((news) => news.id),
+        },
+      },
+      data: {
+        published: true,
+      },
+    });
+  }
+};
+
+/**
+ * Archives all published news items whose expiration date has passed and are not already archived.
+ *
+ * This function queries the database for news items that:
+ * - Are published (`published: true`)
+ * - Have a status different from 'ARCHIVED'
+ * - Have an `expirationDate` less than or equal to the current date
+ *
+ * If any such news items are found, it updates their status to 'ARCHIVED'.
+ */
+const archiveExpiredNews = async () => {
+  const newsToArchive = await prisma.news.findMany({
+    where: {
+      status: { not: 'ARCHIVED' },
+      published: true,
+      expirationDate: {
+        lte: new Date(),
+      },
+    },
+  });
+
+  if (newsToArchive.length > 0) {
+    console.log(
+      `[JOB] Encontrados ${newsToArchive.length} notícias para arquivar`
+    );
+
+    await prisma.news.updateMany({
+      where: {
+        id: { in: newsToArchive.map((news) => news.id) },
+      },
+      data: {
+        status: 'ARCHIVED',
+      },
+    });
+  }
+};
+
+const runMaintenanceTasks = async () => {
+  console.log(`-- [JOB] Iniciando tarefas de manutenção --`);
+
+  try {
+    await publishScheduledNews();
+  } catch (error) {
+    console.error(`[JOB] ❌ Erro ao executar tarefas de publicação: ${error}`);
+  }
+
+  try {
+    await archiveExpiredNews();
+  } catch (error) {
+    console.error(`[JOB] ❌ Erro ao arquivar notícias expiradas: ${error}`);
+  }
+
+  console.log(`-- [JOB] Tarefas de manutenção concluídas --`);
+};
+
+export const scheduleMaintenanceJob = () => {
+  cron.schedule('* * * * *', runMaintenanceTasks);
+  console.log(`[JOB] Tarefas de manutenção agendadas para cada minuto`);
+};


### PR DESCRIPTION
This pull request introduces significant updates to the backend, including the addition of scheduled maintenance jobs for publishing and archiving news, schema updates to support new date fields, and dependency additions for task scheduling. Below is a breakdown of the most important changes:

### Feature Addition: Scheduled Maintenance Jobs
* [`backend/src/shared/jobs/maintenance.job.ts`](diffhunk://#diff-62d3ede66ac5bd9fc93b21311aa36f8d0b0566f6a79bcf97c6cbb0676399b220R1-R101): Added a new job system using `node-cron` to automate publishing approved news items and archiving expired news items. The job runs every minute and logs its activity.
* [`backend/src/server.ts`](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR2-R8): Integrated the scheduled maintenance job into the server startup process.

### Schema Updates
* [`backend/src/modules/publisher/publisher.schemas.ts`](diffhunk://#diff-6569bc610933d3170a89cfa794390c1894d1cd4c3505e9353f845cb7ea44e9c7R40-R42): Updated the `createNewsSchema` to include optional date fields (`publishedAt`, `mainPageDisplayDate`, and `newsListPageDate`) for enhanced news scheduling and display management.

### Dependency Additions
* `backend/package.json` and `backend/package-lock.json`: Added `node-cron` and its type definitions (`@types/node-cron`) as dependencies to support task scheduling functionality. [[1]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR18) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR27) [[3]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R21) [[4]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R30)

These changes collectively enable automated maintenance tasks, improve schema flexibility for news management, and introduce necessary dependencies for task scheduling.