### PR TITLE
Backend/feat/admin

### DIFF
--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -119,3 +119,51 @@ export const rejectChangeHandler: RequestHandler = async (
     next(error);
   }
 };
+
+/**
+ * Handles the request to get all news articles with optional filtering.
+ *
+ * @param {RequestHandler} req - Express request object containing query parameters
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next function for error handling
+ * @returns {Promise<void>} Returns a JSON response with the news articles and pagination
+ *
+ * @throws {500} When an internal server error occurs
+ *
+ * Expected query parameters:
+ * - status: string (optional, filter by news status)
+ * - page: string (optional, page number for pagination)
+ * - limit: string (optional, number of items per page)
+ *
+ * Success response (200):
+ * - message: string (success message)
+ * - data: object (news articles and pagination info)
+ *
+ * @example
+ * ```typescript
+ * const news = await getAllNewsHandler(req, res, next);
+ * ```
+ */
+export const getAllNewsHandler: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  const { status, page, limit } = req.query;
+
+  try {
+    const filters = {
+      status: status as string,
+      page: page ? parseInt(page as string) : undefined,
+      limit: limit ? parseInt(limit as string) : undefined,
+    };
+
+    const result = await adminService.getAllNews(filters);
+    res.status(200).json({
+      message: 'Notícias recuperadas com sucesso',
+      data: result,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -167,3 +167,62 @@ export const getAllNewsHandler: RequestHandler = async (
     next(error);
   }
 };
+
+/**
+ * Handles the request to update a news article directly by an admin (hotfix).
+ *
+ * @param {RequestHandler} req - Express request object containing the news ID, update data, and user information
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next function for error handling
+ * @returns {Promise<void>} Returns a JSON response with the updated news article
+ *
+ * @throws {500} When an internal server error occurs
+ *
+ * Expected request body:
+ * - title: string (optional, updated title)
+ * - text: string (optional, updated text)
+ * - tagsKeywords: string[] (optional, updated tags)
+ * - expirationDate: string (optional, updated expiration date)
+ * - categoryIds: string[] (optional, updated category IDs)
+ * - status: string (optional, updated status)
+ * - published: boolean (optional, updated published status)
+ * - publishedAt: string (optional, updated published date)
+ * - mainPageDisplayDate: string (optional, updated main page display date)
+ * - newsListPageDate: string (optional, updated news list page date)
+ *
+ * Success response (200):
+ * - message: string (success message)
+ * - data: object (updated news article)
+ *
+ * @example
+ * ```typescript
+ * const updatedNews = await updateNewsDirectlyHandler(req, res, next);
+ * ```
+ */
+export const updateNewsDirectlyHandler: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  const { id: newsId } = req.params;
+  const newsData = req.body;
+  const user = req.user;
+
+  if (!user.email) {
+    return next(new Error('Email do usuário não encontrado'));
+  }
+
+  try {
+    const updatedNews = await adminService.updateNewsDirectly(
+      newsId,
+      newsData,
+      user.email
+    );
+    res.status(200).json({
+      message: 'Notícia atualizada com sucesso',
+      data: updatedNews,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -31,3 +31,41 @@ export const getPendingChangesHandler: RequestHandler = async (
     next(error);
   }
 };
+
+/**
+ * Handles the request to approve a specific pending change.
+ *
+ * @param {RequestHandler} req - Express request object containing the change ID and user information
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next function for error handling
+ * @returns {Promise<void>} Returns a JSON response with the approval status
+ *
+ * @throws {500} When an internal server error occurs
+ *
+ * @example
+ * ```typescript
+ * const approvedChange = await approveChangeHandler(req, res, next);
+ * ```
+ */
+export const approveChangeHandler: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  const { id: changeId } = req.params;
+  const user = req.user;
+
+  if (!user.email) {
+    return next(new Error('Email do usuário não encontrado'));
+  }
+
+  try {
+    const approvedChange = await adminService.approveChange(changeId, user.email);
+    res.status(200).json({
+      message: 'Mudança aprovada com sucesso',
+      data: approvedChange,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -1,0 +1,33 @@
+import * as adminService from './admin.services';
+import { RequestHandler } from 'express';
+
+/**
+ * Handles the request to get all pending changes for admin review.
+ *
+ * @param {RequestHandler} req - Express request object
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next function for error handling
+ * @returns {Promise<void>} Returns a JSON response with the pending changes
+ *
+ * @throws {500} When an internal server error occurs
+ *
+ * @example
+ * ```typescript
+ * const pendingChanges = await getPendingChangesHandler(req, res, next);
+ * ```
+ */
+export const getPendingChangesHandler: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  try {
+    const pendingChanges = await adminService.getPendingChanges();
+    res.status(200).json({
+      message: 'Mudanças pendentes recuperadas com sucesso',
+      data: pendingChanges,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -69,3 +69,53 @@ export const approveChangeHandler: RequestHandler = async (
     next(error);
   }
 };
+
+/**
+ * Handles the request to reject a specific pending change.
+ *
+ * @param {RequestHandler} req - Express request object containing the change ID, rejection reason, and user information
+ * @param {Response} res - Express response object
+ * @param {NextFunction} next - Express next function for error handling
+ * @returns {Promise<void>} Returns a JSON response with the rejection status
+ *
+ * @throws {500} When an internal server error occurs
+ *
+ * Expected request body:
+ * - rejectionReason: string (reason for rejection)
+ *
+ * Success response (200):
+ * - message: string (success message)
+ * - data: object (rejected change record)
+ *
+ * @example
+ * ```typescript
+ * const rejectedChange = await rejectChangeHandler(req, res, next);
+ * ```
+ */
+export const rejectChangeHandler: RequestHandler = async (
+  req,
+  res,
+  next
+) => {
+  const { id: changeId } = req.params;
+  const { rejectionReason } = req.body;
+  const user = req.user;
+
+  if (!user.email) {
+    return next(new Error('Email do usuário não encontrado'));
+  }
+
+  try {
+    const rejectedChange = await adminService.rejectChange(
+      changeId,
+      user.email,
+      rejectionReason
+    );
+    res.status(200).json({
+      message: 'Mudança rejeitada com sucesso',
+      data: rejectedChange,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -3,12 +3,14 @@ import {
   getPendingChangesHandler,
   approveChangeHandler,
   rejectChangeHandler,
+  getAllNewsHandler,
 } from './admin.controller';
 import { authMiddleware } from "../../shared/middleware/auth.middleware";
 import { roleMiddleware } from "../../shared/middleware/roles.middleware";
 import { validate } from "../../shared/middleware/validate.middleware";
 import { 
   rejectChangeSchema, 
+  listNewsQuerySchema 
 } from './admin.schemas';
 
 const router = Router();
@@ -34,6 +36,15 @@ router.post(
   roleMiddleware(['ADMIN']),
   validate(rejectChangeSchema),
   rejectChangeHandler
+);
+
+// Rotas para gerenciamento de notícias
+router.get(
+  '/news',
+  authMiddleware,
+  roleMiddleware(['ADMIN']),
+  validate(listNewsQuerySchema),
+  getAllNewsHandler
 );
 
 export default router;

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -4,12 +4,14 @@ import {
   approveChangeHandler,
   rejectChangeHandler,
   getAllNewsHandler,
+  updateNewsDirectlyHandler,
 } from './admin.controller';
 import { authMiddleware } from "../../shared/middleware/auth.middleware";
 import { roleMiddleware } from "../../shared/middleware/roles.middleware";
 import { validate } from "../../shared/middleware/validate.middleware";
 import { 
   rejectChangeSchema, 
+  updateNewsSchema, 
   listNewsQuerySchema 
 } from './admin.schemas';
 
@@ -45,6 +47,14 @@ router.get(
   roleMiddleware(['ADMIN']),
   validate(listNewsQuerySchema),
   getAllNewsHandler
+);
+
+router.put(
+  '/news/:id',
+  authMiddleware,
+  roleMiddleware(['ADMIN']),
+  validate(updateNewsSchema),
+  updateNewsDirectlyHandler
 );
 
 export default router;

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import {
+  getPendingChangesHandler,
+} from './admin.controller';
+import { authMiddleware } from "../../shared/middleware/auth.middleware";
+import { roleMiddleware } from "../../shared/middleware/roles.middleware";
+
+const router = Router();
+
+// Rotas para gerenciamento de mudanças pendentes
+router.get(
+  '/changes/pending',
+  authMiddleware,
+  roleMiddleware(['ADMIN']),
+  getPendingChangesHandler
+);

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import {
   getPendingChangesHandler,
+  approveChangeHandler,
 } from './admin.controller';
 import { authMiddleware } from "../../shared/middleware/auth.middleware";
 import { roleMiddleware } from "../../shared/middleware/roles.middleware";
@@ -14,3 +15,12 @@ router.get(
   roleMiddleware(['ADMIN']),
   getPendingChangesHandler
 );
+
+router.post(
+  '/changes/:id/approve',
+  authMiddleware,
+  roleMiddleware(['ADMIN']),
+  approveChangeHandler
+);
+
+export default router;

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -2,9 +2,14 @@ import { Router } from "express";
 import {
   getPendingChangesHandler,
   approveChangeHandler,
+  rejectChangeHandler,
 } from './admin.controller';
 import { authMiddleware } from "../../shared/middleware/auth.middleware";
 import { roleMiddleware } from "../../shared/middleware/roles.middleware";
+import { validate } from "../../shared/middleware/validate.middleware";
+import { 
+  rejectChangeSchema, 
+} from './admin.schemas';
 
 const router = Router();
 
@@ -21,6 +26,14 @@ router.post(
   authMiddleware,
   roleMiddleware(['ADMIN']),
   approveChangeHandler
+);
+
+router.post(
+  '/changes/:id/reject',
+  authMiddleware,
+  roleMiddleware(['ADMIN']),
+  validate(rejectChangeSchema),
+  rejectChangeHandler
 );
 
 export default router;

--- a/backend/src/modules/admin/admin.schemas.ts
+++ b/backend/src/modules/admin/admin.schemas.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+export const rejectChangeSchema = z.object({
+  body: z.object({
+    rejectionReason: z
+      .string({ required_error: 'O motivo da rejeição é obrigatório.' })
+      .min(1, 'O motivo da rejeição não pode estar vazio.')
+      .max(500, 'O motivo da rejeição não pode ter mais de 500 caracteres.'),
+  }),
+});
+
+export const updateNewsSchema = z.object({
+  body: z.object({
+    title: z.string().min(1, 'O título não pode estar vazio.').optional(),
+    text: z.string().min(1, 'O texto não pode estar vazio.').optional(),
+    tagsKeywords: z.array(z.string()).optional(),
+    expirationDate: z
+      .string()
+      .datetime({ message: 'Formato de data de expiração inválido.' })
+      .optional()
+      .nullable(),
+    categoryIds: z
+      .array(z.string().uuid({ message: 'ID de categoria inválido.' }))
+      .min(1, 'Pelo menos uma categoria é necessária.')
+      .optional(),
+    status: z.enum(['PENDING', 'APPROVED', 'REJECTED', 'ARCHIVED']).optional(),
+    published: z.boolean().optional(),
+    publishedAt: z
+      .string()
+      .datetime({ message: 'Formato de data de publicação inválido.' })
+      .optional()
+      .nullable(),
+    mainPageDisplayDate: z
+      .string()
+      .datetime({
+        message: 'Formato de data de exibição na página principal inválido.',
+      })
+      .optional()
+      .nullable(),
+    newsListPageDate: z
+      .string()
+      .datetime({
+        message: 'Formato de data de exibição na lista de notícias inválido.',
+      })
+      .optional()
+      .nullable(),
+  }),
+});
+
+export const listNewsQuerySchema = z.object({
+  query: z.object({
+    status: z.enum(['PENDING', 'APPROVED', 'REJECTED', 'ARCHIVED']).optional(),
+    page: z.string().regex(/^\d+$/, 'Página deve ser um número.').optional(),
+    limit: z.string().regex(/^\d+$/, 'Limite deve ser um número.').optional(),
+  }),
+});

--- a/backend/src/modules/admin/admin.services.ts
+++ b/backend/src/modules/admin/admin.services.ts
@@ -1,0 +1,48 @@
+import { Prisma } from "@prisma/client";
+import prisma from "../../shared/lib/prisma";
+import { InternalServerError } from "../../shared/errors/InternalServerError";
+import { NotFoundError } from "../../shared/errors/NotFoundError";
+
+/**
+ * Retrieves all pending changes in the system for admin review.
+ *
+ * @returns {Promise<Object[]>} Returns the list of pending changes
+ * @throws {NotFoundError} Throws an error if no pending changes are found
+ *
+ * @example
+ * ```typescript
+ * const pendingChanges = await getPendingChanges();
+ * ```
+ */
+export const getPendingChanges = async () => {
+  const pendingChanges = await prisma.pendingChange.findMany({
+    where: {
+      status: 'PENDING',
+    },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
+      },
+      news: {
+        select: {
+          id: true,
+          title: true,
+          status: true,
+        },
+      },
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+  });
+
+  if (!pendingChanges || pendingChanges.length === 0) {
+    throw new NotFoundError('pendingChanges');
+  }
+
+  return pendingChanges;
+};

--- a/backend/src/modules/admin/admin.services.ts
+++ b/backend/src/modules/admin/admin.services.ts
@@ -46,3 +46,150 @@ export const getPendingChanges = async () => {
 
   return pendingChanges;
 };
+
+/**
+ * Approves a specific pending change and executes the creation/update logic.
+ *
+ * @param {string} changeId - The ID of the pending change to approve
+ * @param {string} reviewerEmail - The email of the admin reviewing the change
+ * @returns {Promise<Object>} Returns the updated pending change record
+ * @throws {NotFoundError} Throws an error if the pending change is not found
+ * @throws {InternalServerError} Throws an error if the approval process fails
+ *
+ * @example
+ * ```typescript
+ * const approvedChange = await approveChange('change-123', 'admin@example.com');
+ * ```
+ */
+export const approveChange = async (changeId: string, reviewerEmail: string) => {
+  const pendingChange = await prisma.pendingChange.findUnique({
+    where: { id: changeId },
+    include: {
+      news: true,
+    },
+  });
+
+  if (!pendingChange) {
+    throw new NotFoundError('pendingChanges');
+  }
+
+  if (pendingChange.status !== 'PENDING') {
+    throw new InternalServerError(
+      new Error(),
+      'Apenas mudanças pendentes podem ser aprovadas'
+    );
+  }
+
+  const reviewer = await prisma.user.findUnique({
+    where: { email: reviewerEmail },
+  });
+
+  if (!reviewer) {
+    throw new InternalServerError(
+      new Error(),
+      'Usuário revisor não encontrado no sistema'
+    );
+  }
+
+  try {
+    // Update the pending change status first
+    const updatedChange = await prisma.pendingChange.update({
+      where: { id: changeId },
+      data: {
+        status: 'APPROVED',
+        reviewerId: reviewer.id,
+        updatedAt: new Date(),
+      },
+    });
+
+    // Execute the change based on type
+    if (pendingChange.type === 'CREATE') {
+      const newsData = pendingChange.content as any;
+      let validCategoryIds: string[] = [];
+      if (newsData.categoryIds && newsData.categoryIds.length > 0) {
+        const existingCategories = await prisma.category.findMany({
+          where: { id: { in: newsData.categoryIds } },
+        });
+        validCategoryIds = existingCategories.map(cat => cat.id);
+      }
+      
+      const newNews = await prisma.news.create({
+        data: {
+          title: newsData.title,
+          text: newsData.text,
+          tagsKeywords: newsData.tagsKeywords || [],
+          expirationDate: newsData.expirationDate ? new Date(newsData.expirationDate) : null,
+          status: 'APPROVED',
+          published: true,
+          publishedAt: new Date(),
+          authorId: pendingChange.authorId,
+          revisorId: reviewer.id,
+          revisionDate: new Date(),
+          categories: validCategoryIds.length > 0 ? {
+            connect: validCategoryIds.map((id: string) => ({ id })),
+          } : undefined,
+          media: newsData.media && newsData.media.length > 0 ? {
+            create: newsData.media.map((media: any) => ({
+              url: media.url,
+              path: media.path,
+              alt: media.alt,
+              title: media.title,
+              description: media.description,
+              caption: media.caption,
+              copyright: media.copyright,
+              type: media.type,
+              order: media.order,
+            })),
+          } : undefined,
+        },
+      });
+
+      await prisma.pendingChange.update({
+        where: { id: changeId },
+        data: { newsId: newNews.id },
+      });
+
+      return { ...updatedChange, createdNews: newNews };
+    } else if (pendingChange.type === 'UPDATE') {
+      const newsData = pendingChange.content as any;
+      
+      let validCategoryIds: string[] = [];
+      if (newsData.categoryIds && newsData.categoryIds.length > 0) {
+        const existingCategories = await prisma.category.findMany({
+          where: { id: { in: newsData.categoryIds } },
+        });
+        validCategoryIds = existingCategories.map(cat => cat.id);
+      }
+      
+      const updatedNews = await prisma.news.update({
+        where: { id: pendingChange.newsId! },
+        data: {
+          title: newsData.title,
+          text: newsData.text,
+          tagsKeywords: newsData.tagsKeywords,
+          expirationDate: newsData.expirationDate ? new Date(newsData.expirationDate) : null,
+          status: 'APPROVED',
+          revisorId: reviewer.id,
+          revisionDate: new Date(),
+          published: newsData.published !== undefined ? newsData.published : true,
+          publishedAt: newsData.publishedAt ? new Date(newsData.publishedAt) : new Date(),
+          mainPageDisplayDate: newsData.mainPageDisplayDate ? new Date(newsData.mainPageDisplayDate) : null,
+          newsListPageDate: newsData.newsListPageDate ? new Date(newsData.newsListPageDate) : null,
+          categories: validCategoryIds.length > 0 ? {
+            set: [],
+            connect: validCategoryIds.map((id: string) => ({ id })),
+          } : undefined,
+        },
+      });
+
+      return { ...updatedChange, updatedNews };
+    }
+
+    return updatedChange;
+  } catch (error) {
+    throw new InternalServerError(
+      error as Error,
+      'Falha ao aprovar a mudança'
+    );
+  }
+};

--- a/backend/src/modules/news/news.controller.ts
+++ b/backend/src/modules/news/news.controller.ts
@@ -1,0 +1,53 @@
+import { RequestHandler } from 'express';
+import * as newsService from './news.service';
+
+/**
+ * Handler para listar notícias publicadas (público).
+ *
+ * @route GET /api/news
+ * @query page, limit
+ * @returns {200} Lista paginada de notícias publicadas
+ * @throws {404} Se não houver notícias publicadas
+ *
+ * @example
+ * GET /api/news?page=1&limit=10
+ */
+export const getPublishedNewsHandler: RequestHandler = async (req, res, next) => {
+  try {
+    const { page, limit } = req.query;
+    const result = await newsService.getPublishedNews({
+      page: page ? parseInt(page as string) : 1,
+      limit: limit ? parseInt(limit as string) : 10,
+    });
+    res.status(200).json({
+      message: 'Notícias publicadas encontradas com sucesso',
+      data: result,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Handler para buscar uma notícia publicada por ID (público).
+ *
+ * @route GET /api/news/:id
+ * @param {string} id - ID da notícia
+ * @returns {200} Notícia encontrada
+ * @throws {404} Se a notícia não existir ou não estiver publicada
+ *
+ * @example
+ * GET /api/news/uuid
+ */
+export const getPublishedNewsByIdHandler: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const news = await newsService.getPublishedNewsById(id);
+    res.status(200).json({
+      message: 'Notícia encontrada com sucesso',
+      data: news,
+    });
+  } catch (error) {
+    next(error);
+  }
+}; 

--- a/backend/src/modules/news/news.controller.ts
+++ b/backend/src/modules/news/news.controller.ts
@@ -14,10 +14,11 @@ import * as newsService from './news.service';
  */
 export const getPublishedNewsHandler: RequestHandler = async (req, res, next) => {
   try {
-    const { page, limit } = req.query;
+    const { page, limit, search } = req.query;
     const result = await newsService.getPublishedNews({
       page: page ? parseInt(page as string) : 1,
       limit: limit ? parseInt(limit as string) : 10,
+      search: search as string,
     });
     res.status(200).json({
       message: 'Notícias publicadas encontradas com sucesso',

--- a/backend/src/modules/news/news.routes.ts
+++ b/backend/src/modules/news/news.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { listPublishedNewsQuerySchema } from './news.schemas';
+import { validate } from '../../shared/middleware/validate.middleware';
+import { getPublishedNewsHandler, getPublishedNewsByIdHandler } from './news.controller';
+
+const router = Router();
+
+router.get('/', validate(listPublishedNewsQuerySchema), getPublishedNewsHandler);
+router.get('/:id', getPublishedNewsByIdHandler);
+
+export default router; 

--- a/backend/src/modules/news/news.schemas.ts
+++ b/backend/src/modules/news/news.schemas.ts
@@ -4,5 +4,6 @@ export const listPublishedNewsQuerySchema = z.object({
   query: z.object({
     page: z.string().regex(/^\d+$/, 'Página deve ser um número.').optional(),
     limit: z.string().regex(/^\d+$/, 'Limite deve ser um número.').optional(),
+    search: z.string().optional(),
   }),
-}); 
+});

--- a/backend/src/modules/news/news.schemas.ts
+++ b/backend/src/modules/news/news.schemas.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const listPublishedNewsQuerySchema = z.object({
+  query: z.object({
+    page: z.string().regex(/^\d+$/, 'Página deve ser um número.').optional(),
+    limit: z.string().regex(/^\d+$/, 'Limite deve ser um número.').optional(),
+  }),
+}); 

--- a/backend/src/modules/news/news.service.ts
+++ b/backend/src/modules/news/news.service.ts
@@ -1,0 +1,122 @@
+import prisma from '../../shared/lib/prisma';
+import { NotFoundError } from '../../shared/errors/NotFoundError';
+
+/**
+ * Lista todas as notícias publicadas, com paginação.
+ *
+ * @param {Object} filters - Filtros opcionais de paginação
+ * @param {number} [filters.page=1] - Página atual
+ * @param {number} [filters.limit=10] - Limite de itens por página
+ * @returns {Promise<Object>} Lista de notícias e paginação
+ * @throws {NotFoundError} Se não houver notícias publicadas
+ *
+ * @example
+ * const result = await getPublishedNews({ page: 1, limit: 10 });
+ */
+export const getPublishedNews = async (
+  filters?: {
+    page?: number;
+    limit?: number
+  }) => {
+  const page = filters?.page || 1;
+  const limit = filters?.limit || 10;
+  const skip = (page - 1) * limit;
+
+  const [news, total] = await Promise.all([
+    prisma.news.findMany({
+      where: {
+        status: 'APPROVED',
+        published: true,
+      },
+      include: {
+        author: {
+          select: {
+            id: true,
+            name: true
+          }
+        },
+        categories: {
+          select: {
+            id: true,
+            name: true
+          }
+        },
+        media: {
+          orderBy: {
+            order: 'asc'
+          }
+        },
+      },
+      orderBy: {
+        publishedAt: 'desc'
+      },
+      skip,
+      take: limit,
+    }),
+    prisma.news.count({
+      where: {
+        status: 'APPROVED',
+        published: true
+      }
+    }),
+  ]);
+
+  if (!news || news.length === 0) {
+    throw new NotFoundError('news');
+  }
+
+  return {
+    news,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  };
+};
+
+/**
+ * Busca uma notícia publicada pelo ID.
+ *
+ * @param {string} id - ID da notícia
+ * @returns {Promise<Object>} Notícia encontrada
+ * @throws {NotFoundError} Se a notícia não existir ou não estiver publicada
+ *
+ * @example
+ * const news = await getPublishedNewsById('uuid');
+ */
+export const getPublishedNewsById = async (id: string) => {
+  const news = await prisma.news.findUnique({
+    where: {
+      id,
+      status: 'APPROVED',
+      published: true
+    },
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true
+        }
+      },
+      categories: {
+        select: {
+          id: true,
+          name: true
+        }
+      },
+      media: {
+        orderBy: {
+          order: 'asc'
+        }
+      },
+    },
+  });
+
+  if (!news) {
+    throw new NotFoundError('news');
+  }
+
+  return news;
+}; 

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import categoryRoutes from './modules/categories/categories.router';
 import authRoutes from './modules/auth/auth.router';
 import publisherRoutes from './modules/publisher/publisher.routes';
+import adminRoutes from './modules/admin/admin.routes';
 
 const router = Router();
 
@@ -11,6 +12,7 @@ router.get('/', (req, res) => {
 
 router.use('/categories', categoryRoutes);
 router.use('/publisher', publisherRoutes);
+router.use('/admin', adminRoutes);
 router.use('/auth', authRoutes);
 
 export default router;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -3,6 +3,7 @@ import categoryRoutes from './modules/categories/categories.router';
 import authRoutes from './modules/auth/auth.router';
 import publisherRoutes from './modules/publisher/publisher.routes';
 import adminRoutes from './modules/admin/admin.routes';
+import newsRoutes from './modules/news/news.routes';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use('/categories', categoryRoutes);
 router.use('/publisher', publisherRoutes);
 router.use('/admin', adminRoutes);
 router.use('/auth', authRoutes);
+router.use('/news', newsRoutes);
 
 export default router;

--- a/backend/src/shared/middleware/roles.middleware.ts
+++ b/backend/src/shared/middleware/roles.middleware.ts
@@ -5,9 +5,10 @@ export const roleMiddleware = (allowedRoles: string[]) => {
     const userRole = (req as any).user?.user_metadata?.role;
 
     if (!userRole || !allowedRoles.includes(userRole)) {
-      return res
+      res
         .status(403)
         .json({ message: 'Acesso negado: Permissão insuficiente' });
+      return;
     }
 
     next();


### PR DESCRIPTION
# Módulo: Admin (/api/admin)
### Responsável: Gerenciar o fluxo de aprovação e o conteúdo de todos os usuários.

## [ADMIN] Lista todas as solicitações de mudança com status PENDING.
### Retorna todas as mudanças pendentes
GET /api/admin/changes/pending

## [ADMIN] Aprova uma solicitação de mudança específica.
### Executa a lógica de criar/atualizar a notícia na tabela principal e muda o status da solicitação.
POST /api/admin/changes/:id/approve

## [ADMIN] Rejeita uma solicitação de mudança específica.
### Recebe um motivo no corpo da requisição.
POST /api/admin/changes/:id/reject

## [ADMIN] Lista TODAS as notícias do sistema, com capacidade de filtrar por status.
### Ex: /api/admin/news?status=PENDING
GET /api/admin/news

## [ADMIN] Permite que um administrador edite diretamente uma notícia já publicada (hotfix).
PUT /api/admin/news/:id

# Módulo: News (/api/news)
### Rotas públicas para acessar as notícias

## [NEWS] Retorna todas as notícias publicadas paginadas e com pesquisa
### Permite pesquisar por título ou conteúdo
GET /news

## [NEWS] Retorna informações de uma notícia específica publicada
### Busca notícia pelo ID
GET /news/:id